### PR TITLE
Use Github specific campaign url

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,1 @@
-
-custom: https://publicintegrity.org/support-us
+custom: https://checkout.fundjournalism.org/memberform?org_id=cpi&campaign=701f4000000FOWDAA4


### PR DESCRIPTION
Shane generated this campaign id for use on Github. He said that the current URL `publicintegrity.org/support-us` is part of a different campaign that is specific to the website.